### PR TITLE
Added getSMSInterrupt/setSMSInterrupt functions to allow RI pin to interrupt upon inbound SMS

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -321,6 +321,18 @@ boolean Adafruit_FONA::incomingCallNumber(char* phonenum) {
 
 /********* SMS **********************************************************/
 
+uint8_t Adafruit_FONA::getSMSInterrupt(void) {
+  uint16_t reply;
+
+  if (! sendParseReply(F("AT+CFGRI?"), F("+CFGRI: "), &reply) ) return 0;
+
+  return reply;
+}
+
+boolean Adafruit_FONA::setSMSInterrupt(uint8_t i) {
+  return sendCheckReply(F("AT+CFGRI="), i, F("OK"));
+}
+
 int8_t Adafruit_FONA::getNumSMS(void) {
   uint16_t numsms;
 

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -89,6 +89,8 @@ class Adafruit_FONA : public Stream {
   int8_t getFMSignalLevel(uint16_t station);
 
   // SMS handling
+  boolean setSMSInterrupt(uint8_t i);
+  uint8_t getSMSInterrupt(void);
   int8_t getNumSMS(void);
   boolean readSMS(uint8_t i, char *smsbuff, uint16_t max, uint16_t *readsize);
   boolean sendSMS(char *smsaddr, char *smsmsg);

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check out the links above for our tutorials and wiring diagrams
 
 Written by Limor Fried/Ladyada for Adafruit Industries.  
 BSD license, all text above must be included in any redistribution
+With updates from Samy Kamkar
 
 To download. click the DOWNLOADS button in the top right corner, rename the uncompressed folder Adafruit_FONA 
 Check that the Adafruit_FONA folder contains Adafruit_FONA.cpp and Adafruit_FONA.h


### PR DESCRIPTION
You can now use setSMSInterrupt() to enable/disable the RI pin to send an interrupt upon receiving an SMS. Previously, FONA would only interrupt upon receiving calls so you would need to poll for new SMS', now you can simply listen for the interrupt and tuck your microcontroller in and put it to sleep.