### PR TITLE
Removed a wrongly copied documentation comment.

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -76,7 +76,6 @@ boolean Adafruit_FONA::begin(Stream &port) {
 
 /********* Real Time Clock ********************************************/
 
-/* returns value in mV (uint16_t) */
 boolean Adafruit_FONA::readRTC(uint8_t *year, uint8_t *month, uint8_t *date, uint8_t *hr, uint8_t *min, uint8_t *sec) {
   uint16_t v;
   sendParseReply(F("AT+CCLK?"), F("+CCLK: "), &v, '/', 0);


### PR DESCRIPTION
The comment describing *readRTC* is clearly a copy from the *getBattVoltage*, since most of the methods aren't documented, I just removed the comment instead of making a new one.