### PR TITLE
CID value in HTTP_initialize needs to be quoted

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -686,7 +686,7 @@ boolean Adafruit_FONA::HTTP_initialize(char *url) {
   // Initialize and set parameters
   if (! sendCheckReply(F("AT+HTTPINIT"), F("OK")))
     return false;
-  if (! sendCheckReply(F("AT+HTTPPARA=\"CID\",1"), F("OK")))
+  if (! sendCheckReply(F("AT+HTTPPARA=\"CID\",\"1\""), F("OK")))
     return false;
   if (! sendCheckReplyQuoted(F("AT+HTTPPARA=\"UA\","), useragent, F("OK"), 10000))
     return false;


### PR DESCRIPTION
A bug I found when trying to use the HTTP GET method.