### PR TITLE
Added leonardo version of test example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 install:
   - ln -s $PWD /usr/local/share/arduino/libraries/Adafruit_FONA
   - arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"
+  - arduino --install-boards arduino:avr
 script:
   - arduino --verify --board arduino:avr:uno $PWD/examples/FONAtest/FONAtest.ino
   - arduino --verify --board arduino:avr:leonardo $PWD/examples/Leo_FONAtest/Leo_FONAtest.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"
 script:
   - arduino --verify --board arduino:avr:uno $PWD/examples/FONAtest/FONAtest.ino
+  - arduino --verify --board arduino:avr:leonardo $PWD/examples/Leo_FONAtest/Leo_FONAtest.ino
   - arduino --verify --board arduino:avr:uno $PWD/examples/IncomingCall/IncomingCall.ino
   - arduino --verify --board arduino:avr:uno $PWD/examples/AdafruitIO_GPS/AdafruitIO_GPS.ino
 notifications:

--- a/examples/Leo_FONAtest/Leo_Fonatest.ino
+++ b/examples/Leo_FONAtest/Leo_Fonatest.ino
@@ -20,6 +20,8 @@
 /*
 THIS CODE IS STILL IN PROGRESS!
 
+This code is intended for use with Arduino Leonardo and other ATmega32U4-based Arduinos
+
 Open up the serial console on the Arduino at 115200 baud to interact with FONA
 
 Note that if you need to set a GPRS APN, username, and password scroll down to
@@ -29,8 +31,8 @@ the commented section below at the end of the setup() function.
 #include <SoftwareSerial.h>
 #include "Adafruit_FONA.h"
 
-#define FONA_RX 2
-#define FONA_TX 3
+#define FONA_RX 7
+#define FONA_TX 8
 #define FONA_RST 4
 
 // this is a large buffer for replies


### PR DESCRIPTION
Took me a while to figure out that SoftwareSerial only works on certain pins on the Leonardo (and other ATmega32U4-based Arduinos).

I added a Leonardo version of the test example, similar to the examples in the Adafruit-GPS-Library.

I also cleaned up a little and stripped some trailing spaces.