### PR TITLE
Reverse lat/long for GSM

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -1089,11 +1089,12 @@ boolean Adafruit_FONA::getGSMLoc(float *lat, float *lon) {
     return false;
 
   // tokenize the gps buffer to locate the lat & long
-  char *latp = strtok(gpsbuffer, ",");
+  char *longp = strtok(gpsbuffer, ",");
+  if (! longp) return false;
+
+  char *latp = strtok(NULL, ",");
   if (! latp) return false;
 
-  char *longp = strtok(NULL, ",");
-  if (! longp) return false;
 
   *lat = atof(latp);
   *lon = atof(longp);


### PR DESCRIPTION
The Sim80X returns longitude before latitude for `CIPGSMLOC`

See p236 of http://www.adafruit.com/datasheets/sim800_series_at_command_manual_v1.01.pdf