### PR TITLE
Removed some strings from the stack, moving them to program space.

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -159,7 +159,7 @@ uint8_t Adafruit_FONA::unlockSIM(char *pin)
 }
 
 uint8_t Adafruit_FONA::getSIMCCID(char *ccid) {
-  getReply("AT+CCID");
+  getReply(F("AT+CCID"));
   // up to 28 chars for reply, 20 char total ccid
   if (replybuffer[0] == '+') {
     // fona 3g?
@@ -178,7 +178,7 @@ uint8_t Adafruit_FONA::getSIMCCID(char *ccid) {
 /********* IMEI **********************************************************/
 
 uint8_t Adafruit_FONA::getIMEI(char *imei) {
-  getReply("AT+GSN");
+  getReply(F("AT+GSN"));
 
   // up to 15 chars
   strncpy(imei, replybuffer, 15);
@@ -492,7 +492,7 @@ boolean Adafruit_FONA::getSMSSender(uint8_t i, char *sender, int senderlen) {
 }
 
 boolean Adafruit_FONA::sendSMS(char *smsaddr, char *smsmsg) {
-  if (! sendCheckReply("AT+CMGF=1", "OK")) return -1;
+  if (! sendCheckReply(F("AT+CMGF=1"), F("OK"))) return -1;
 
   char sendcmd[30] = "AT+CMGS=\"";
   strncpy(sendcmd+9, smsaddr, 30-9-2);  // 9 bytes beginning, 2 bytes for close quote + null
@@ -506,22 +506,22 @@ boolean Adafruit_FONA::sendSMS(char *smsaddr, char *smsmsg) {
   mySerial->println();
   mySerial->write(0x1A);
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.println("^Z");
+  Serial.println(F("^Z"));
 #endif
   if ( (_type == FONA3G_A) || (_type == FONA3G_E) ) {
     // Eat two sets of CRLF
     readline(200);
-    //Serial.print("Line 1: "); Serial.println(strlen(replybuffer));
+    //Serial.print(F("Line 1: ")); Serial.println(strlen(replybuffer));
     readline(200);
-    //Serial.print("Line 2: "); Serial.println(strlen(replybuffer));
+    //Serial.print(F("Line 2: ")); Serial.println(strlen(replybuffer));
   }
   readline(10000); // read the +CMGS reply, wait up to 10 seconds!!!
-  //Serial.print("Line 3: "); Serial.println(strlen(replybuffer));
+  //Serial.print(F("Line 3: ")); Serial.println(strlen(replybuffer));
   if (strstr(replybuffer, "+CMGS") == 0) {
     return false;
   }
   readline(1000); // read OK
-  //Serial.print("* "); Serial.println(replybuffer);
+  //Serial.print(F("* ")); Serial.println(replybuffer);
 
   if (strcmp(replybuffer, "OK") != 0) {
     return false;
@@ -532,7 +532,7 @@ boolean Adafruit_FONA::sendSMS(char *smsaddr, char *smsmsg) {
 
 
 boolean Adafruit_FONA::deleteSMS(uint8_t i) {
-    if (! sendCheckReply("AT+CMGF=1", "OK")) return -1;
+    if (! sendCheckReply(F("AT+CMGF=1"), F("OK"))) return -1;
   // read an sms
   char sendbuff[12] = "AT+CMGD=000";
   sendbuff[8] = (i / 100) + '0';
@@ -1154,7 +1154,7 @@ boolean Adafruit_FONA::TCPsend(char *packet, uint8_t len) {
   Serial.println(len);
 
   for (uint16_t i=0; i<len; i++) {
-    Serial.print(" 0x");
+    Serial.print(F(" 0x"));
     Serial.print(packet[i], HEX);
   }
   Serial.println();
@@ -1204,7 +1204,7 @@ uint16_t Adafruit_FONA::TCPread(uint8_t *buff, uint8_t len) {
 #ifdef ADAFRUIT_FONA_DEBUG
   Serial.print (avail); Serial.println(F(" bytes read"));
   for (uint8_t i=0;i<avail;i++) {
-    Serial.print(" 0x"); Serial.print(replybuffer[i], HEX);
+    Serial.print(F(" 0x")); Serial.print(replybuffer[i], HEX);
   }
   Serial.println();
 #endif
@@ -1231,7 +1231,7 @@ void Adafruit_FONA::HTTP_para_start(const __FlashStringHelper *parameter,
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> ");
+  Serial.print(F("\t---> "));
   Serial.print(F("AT+HTTPPARA=\""));
   Serial.print(parameter);
   Serial.println('"');
@@ -1279,16 +1279,16 @@ boolean Adafruit_FONA::HTTP_data(uint32_t size, uint32_t maxTime) {
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> ");
+  Serial.print(F("\t---> "));
   Serial.print(F("AT+HTTPDATA="));
   Serial.print(size);
-  Serial.print(",");
+  Serial.print(F(","));
   Serial.println(maxTime);
 #endif
 
   mySerial->print(F("AT+HTTPDATA="));
   mySerial->print(size);
-  mySerial->print(",");
+  mySerial->print(F(","));
   mySerial->println(maxTime);
 
   return expectReply(F("DOWNLOAD"));
@@ -1333,8 +1333,8 @@ boolean Adafruit_FONA::HTTP_GET_start(char *url,
   if (! HTTP_action(FONA_HTTP_GET, status, datalen))
     return false;
 
-  Serial.print("Status: "); Serial.println(*status);
-  Serial.print("Len: "); Serial.println(*datalen);
+  Serial.print(F("Status: ")); Serial.println(*status);
+  Serial.print(F("Len: ")); Serial.println(*datalen);
 
   // HTTP response data
   if (! HTTP_readall(datalen))
@@ -1368,8 +1368,8 @@ boolean Adafruit_FONA_3G::HTTP_GET_start(char *ipaddr, char *path, uint16_t port
   if (! HTTP_action(FONA_HTTP_GET, status, datalen))
     return false;
 
-  Serial.print("Status: "); Serial.println(*status);
-  Serial.print("Len: "); Serial.println(*datalen);
+  Serial.print(F("Status: ")); Serial.println(*status);
+  Serial.print(F("Len: ")); Serial.println(*datalen);
 
   // HTTP response data
   if (! HTTP_readall(datalen))
@@ -1405,8 +1405,8 @@ boolean Adafruit_FONA::HTTP_POST_start(char *url,
   if (! HTTP_action(FONA_HTTP_POST, status, datalen))
     return false;
 
-  Serial.print("Status: "); Serial.println(*status);
-  Serial.print("Len: "); Serial.println(*datalen);
+  Serial.print(F("Status: ")); Serial.println(*status);
+  Serial.print(F("Len: ")); Serial.println(*datalen);
 
   // HTTP response data
   if (! HTTP_readall(datalen))
@@ -1537,7 +1537,7 @@ uint8_t Adafruit_FONA::readline(uint16_t timeout, boolean multiline) {
         }
       }
       replybuffer[replyidx] = c;
-      //Serial.print(c, HEX); Serial.print("#"); Serial.println(c);
+      //Serial.print(c, HEX); Serial.print(F("#")); Serial.println(c);
       replyidx++;
     }
 
@@ -1555,7 +1555,7 @@ uint8_t Adafruit_FONA::getReply(char *send, uint16_t timeout) {
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-    Serial.print("\t---> "); Serial.println(send);
+    Serial.print(F("\t---> ")); Serial.println(send);
 #endif
 
   mySerial->println(send);
@@ -1571,7 +1571,7 @@ uint8_t Adafruit_FONA::getReply(const __FlashStringHelper *send, uint16_t timeou
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> "); Serial.println(send);
+  Serial.print(F("\t---> ")); Serial.println(send);
 #endif
 
   mySerial->println(send);
@@ -1588,7 +1588,7 @@ uint8_t Adafruit_FONA::getReply(const __FlashStringHelper *prefix, char *suffix,
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> "); Serial.print(prefix); Serial.println(suffix);
+  Serial.print(F("\t---> ")); Serial.print(prefix); Serial.println(suffix);
 #endif
 
   mySerial->print(prefix);
@@ -1606,7 +1606,7 @@ uint8_t Adafruit_FONA::getReply(const __FlashStringHelper *prefix, int32_t suffi
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> "); Serial.print(prefix); Serial.println(suffix, DEC);
+  Serial.print(F("\t---> ")); Serial.print(prefix); Serial.println(suffix, DEC);
 #endif
 
   mySerial->print(prefix);
@@ -1624,8 +1624,8 @@ uint8_t Adafruit_FONA::getReply(const __FlashStringHelper *prefix, int32_t suffi
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> "); Serial.print(prefix);
-  Serial.print(suffix1, DEC); Serial.print(","); Serial.println(suffix2, DEC);
+  Serial.print(F("\t---> ")); Serial.print(prefix);
+  Serial.print(suffix1, DEC); Serial.print(F(",")); Serial.println(suffix2, DEC);
 #endif
 
   mySerial->print(prefix);
@@ -1645,7 +1645,7 @@ uint8_t Adafruit_FONA::getReplyQuoted(const __FlashStringHelper *prefix, const _
   flushInput();
 
 #ifdef ADAFRUIT_FONA_DEBUG
-  Serial.print("\t---> "); Serial.print(prefix);
+  Serial.print(F("\t---> ")); Serial.print(prefix);
   Serial.print('"'); Serial.print(suffix); Serial.println('"');
 #endif
 
@@ -1666,11 +1666,11 @@ boolean Adafruit_FONA::sendCheckReply(char *send, char *reply, uint16_t timeout)
 
 /*
   for (uint8_t i=0; i<strlen(replybuffer); i++) {
-    Serial.print(replybuffer[i], HEX); Serial.print(" ");
+    Serial.print(replybuffer[i], HEX); Serial.print(F(" "));
   }
   Serial.println();
   for (uint8_t i=0; i<strlen(reply); i++) {
-    Serial.print(reply[i], HEX); Serial.print(" ");
+    Serial.print(reply[i], HEX); Serial.print(F(" "));
   }
   Serial.println();
   */

--- a/examples/FONAtest/FONAtest.ino
+++ b/examples/FONAtest/FONAtest.ino
@@ -91,7 +91,7 @@ void setup() {
   char imei[15] = {0}; // MUST use a 16 character buffer for IMEI!
   uint8_t imeiLen = fona.getIMEI(imei);
   if (imeiLen > 0) {
-    Serial.print("SIM card IMEI: "); Serial.println(imei);
+    Serial.print(F("SIM card IMEI: ")); Serial.println(imei);
   }
 
   // Optionally configure a GPRS APN, username, and password.
@@ -248,7 +248,7 @@ void loop() {
         uint8_t n = fona.getRSSI();
         int8_t r;
 
-        Serial.print(F("RSSI = ")); Serial.print(n); Serial.print(": ");
+        Serial.print(F("RSSI = ")); Serial.print(n); Serial.print(F(": "));
         if (n == 0) r = -115;
         if (n == 1) r = -111;
         if (n == 31) r = -52;
@@ -298,9 +298,9 @@ void loop() {
         uint8_t v = fona.getVolume();
         Serial.print(v);
         if ( (type == FONA3G_A) || (type == FONA3G_E) ) {
-          Serial.println(" / 8");
+          Serial.println(F(" / 8"));
         } else {
-          Serial.println("%");
+          Serial.println(F("%"));
         }
         break;
       }
@@ -485,7 +485,7 @@ void loop() {
 
         // Retrieve SMS sender address/phone number.
         if (! fona.getSMSSender(smsn, replybuffer, 250)) {
-          Serial.println("Failed!");
+          Serial.println(F("Failed!"));
           break;
         }
         Serial.print(F("FROM: ")); Serial.println(replybuffer);
@@ -493,11 +493,11 @@ void loop() {
         // Retrieve SMS value.
         uint16_t smslen;
         if (! fona.readSMS(smsn, replybuffer, 250, &smslen)) { // pass in buffer and max len!
-          Serial.println("Failed!");
+          Serial.println(F("Failed!"));
           break;
         }
         Serial.print(F("***** SMS #")); Serial.print(smsn);
-        Serial.print(" ("); Serial.print(smslen); Serial.println(F(") bytes *****"));
+        Serial.print(F(" (")); Serial.print(smslen); Serial.println(F(") bytes *****"));
         Serial.println(replybuffer);
         Serial.println(F("*****"));
 
@@ -531,7 +531,7 @@ void loop() {
           }
 
           Serial.print(F("***** SMS #")); Serial.print(smsn);
-          Serial.print(" ("); Serial.print(smslen); Serial.println(F(") bytes *****"));
+          Serial.print(F(" (")); Serial.print(smslen); Serial.println(F(") bytes *****"));
           Serial.println(replybuffer);
           Serial.println(F("*****"));
         }
@@ -695,7 +695,7 @@ void loop() {
 
         Serial.println(F("****"));
         if (!fona.HTTP_GET_start(url, &statuscode, (uint16_t *)&length)) {
-          Serial.println("Failed!");
+          Serial.println(F("Failed!"));
           break;
         }
         while (length > 0) {
@@ -736,7 +736,7 @@ void loop() {
 
         Serial.println(F("****"));
         if (!fona.HTTP_POST_start(url, F("text/plain"), (uint8_t *) data, strlen(data), &statuscode, (uint16_t *)&length)) {
-          Serial.println("Failed!");
+          Serial.println(F("Failed!"));
           break;
         }
         while (length > 0) {
@@ -827,7 +827,7 @@ uint8_t readline(char *buff, uint8_t maxbuff, uint16_t timeout) {
     while (Serial.available()) {
       char c =  Serial.read();
 
-      //Serial.print(c, HEX); Serial.print("#"); Serial.println(c);
+      //Serial.print(c, HEX); Serial.print(F("#")); Serial.println(c);
 
       if (c == '\r') continue;
       if (c == 0xA) {

--- a/examples/FONAtest/FONAtest.ino
+++ b/examples/FONAtest/FONAtest.ino
@@ -87,11 +87,11 @@ void setup() {
       Serial.println(F("???")); break;
   }
   
-  // Print SIM card IMEI number.
+ // Print module IMEI number.
   char imei[15] = {0}; // MUST use a 16 character buffer for IMEI!
   uint8_t imeiLen = fona.getIMEI(imei);
   if (imeiLen > 0) {
-    Serial.print(F("SIM card IMEI: ")); Serial.println(imei);
+    Serial.print(F("Module IMEI: ")); Serial.println(imei);
   }
 
   // Optionally configure a GPRS APN, username, and password.


### PR DESCRIPTION
I found some strings in code that were not marked with the `F("")` so the string will be placed in program space (flash memory) instead of being loaded in RAM as soon as the program starts, bloating the RAM unnecessarily.

WARNING: I didn't test these changes, I don't have the proper hardware here or the software now to test, but since they are simple changes I am not afraid of any problems, so please merge at your own risk.