### PR TITLE
Fix for AT+CSTT command call

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -1152,11 +1152,11 @@ boolean Adafruit_FONA::enableGPRS(boolean onoff) {
       mySerial->print(F("AT+CSTT=\""));
       mySerial->print(apn);
       if (apnusername) {
-	mySerial->println("\",\"");
+	mySerial->print("\",\"");
 	mySerial->print(apnusername);
       }
       if (apnpassword) {
-	mySerial->println("\",\"");
+	mySerial->print("\",\"");
 	mySerial->print(apnpassword);
       }
       mySerial->println("\"");
@@ -1174,13 +1174,8 @@ boolean Adafruit_FONA::enableGPRS(boolean onoff) {
       }
       DEBUG_PRINTLN("\"");
       
-      uint8_t l = readline(2000);
-      DEBUG_PRINT("\t<---"); DEBUG_PRINTLN(replybuffer);
-      return (prog_char_strcmp(replybuffer, (prog_char*)ok_reply) == 0);
-
-      if (! sendCheckReplyQuoted(F("AT+CSTT="), apn, ok_reply, 10000))
-        return false;
-
+      if (! expectReply(ok_reply)) return false;
+    
       // set username/password
       if (apnusername) {
         // Send command AT+SAPBR=3,1,"USER","<user>" where <user> is the configured APN username.


### PR DESCRIPTION
- Ensure the command is sent on one line by replacing some println() by print()
- Remove duplicated send to AT+CSTT
- Use expectReply() for AT+CSTT answer check and only return on failure

See [this Forum entry](https://forums.adafruit.com/viewtopic.php?f=54&t=87856) for more context.